### PR TITLE
Add Arch Linux install to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ You can get Windows builds [here](https://github.com/tjohnman/Obsession/releases
 
 You can find Obsession on [MacPorts](https://ports.macports.org/port/Obsession/details/).
 
+### Arch Linux
+
+You can find Obsession on the [AUR](https://aur.archlinux.org/packages/obsession-git/).
+
 Building
 --------
 


### PR DESCRIPTION
I used to be an avid Hotline user, came across Obsession, and love what you are working on.

I don't use a Mac anymore, so I figured I would get this running on my Arch Linux machine, and it was relatively simple! The patch was to get things building on Qt5, and I removed the empty debug file that gets created every time you run Obsession.

https://aur.archlinux.org/cgit/aur.git/tree/qt5.patch?h=obsession-git

Once I got it all working, I went ahead and packaged it up in the AUR for you.

https://aur.archlinux.org/packages/obsession-git

Here is a screenshot of it running on my Linux box!

![image](https://github.com/user-attachments/assets/7c652bea-9858-43f8-b18e-d424b912af98)

Thanks for building an awesome Hotline client!