### PR TITLE
Increase Label Width for Request Account Dialog

### DIFF
--- a/src/dialogcreateaccount.ui
+++ b/src/dialogcreateaccount.ui
@@ -62,7 +62,7 @@
     <rect>
      <x>10</x>
      <y>10</y>
-     <width>251</width>
+     <width>341</width>
      <height>16</height>
     </rect>
    </property>

--- a/src/dialogrequestaccount.ui
+++ b/src/dialogrequestaccount.ui
@@ -52,7 +52,7 @@
     <rect>
      <x>10</x>
      <y>10</y>
-     <width>251</width>
+     <width>341</width>
      <height>16</height>
     </rect>
    </property>


### PR DESCRIPTION
Currently the label is cut off in the "View account" and "Create new account" windows.

![image](https://github.com/user-attachments/assets/d8ce0cb3-4a7c-4fb4-95ed-eeca08ee47e9)

This just increases the width so it displays properly.

![image](https://github.com/user-attachments/assets/3df60dcd-0ce5-4902-87da-93106f891054)
